### PR TITLE
Add magic stat, reorder player stats

### DIFF
--- a/client/src/components/inventory/PlayerStats.tsx
+++ b/client/src/components/inventory/PlayerStats.tsx
@@ -1,9 +1,10 @@
 interface PlayerStatsProps {
   stats: {
-    damage: number;
-    defense: number;
-    speed: number;
     health: number;
+    defense: number;
+    damage: number;
+    magic: number;
+    speed: number;
   };
 }
 
@@ -27,10 +28,11 @@ const PlayerStats = ({ stats }: PlayerStatsProps) => {
     <div className="bg-gray-800 rounded-lg p-6">
       <h2 className="text-2xl font-bold text-white mb-6">Player Stats</h2>
       <div className="space-y-6">
-        <StatBar label="Damage" value={stats.damage} />
-        <StatBar label="Defense" value={stats.defense} />
-        <StatBar label="Speed" value={stats.speed} />
         <StatBar label="Health" value={stats.health} max={500} />
+        <StatBar label="Defense" value={stats.defense} />
+        <StatBar label="Damage" value={stats.damage} />
+        <StatBar label="Magic" value={stats.magic} />
+        <StatBar label="Speed" value={stats.speed} />
       </div>
     </div>
   );

--- a/client/src/pages/Inventory.tsx
+++ b/client/src/pages/Inventory.tsx
@@ -13,10 +13,11 @@ const Inventory = () => {
   if (!user) return null;
 
   const defaultStats = {
-    damage: 10,
-    defense: 5,
-    speed: 10,
     health: 100,
+    defense: 5,
+    damage: 10,
+    magic: 0,
+    speed: 10,
   };
 
   const defaultEquippedItems = {

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -13,10 +13,11 @@ export interface User {
     potion: Item | null;
   };
   stats: {
-    damage: number;
-    defense: number;
-    speed: number;
     health: number;
+    defense: number;
+    damage: number;
+    magic: number;
+    speed: number;
   };
   achievements: Achievement[];
   gameStats: GameStats;

--- a/server/src/models/user.model.js
+++ b/server/src/models/user.model.js
@@ -91,21 +91,25 @@ const userSchema = new mongoose.Schema(
       },
     },
     stats: {
-      damage: {
+      health: {
         type: Number,
-        default: 10,
+        default: 100,
       },
       defense: {
         type: Number,
         default: 5,
       },
-      speed: {
+      damage: {
         type: Number,
         default: 10,
       },
-      health: {
+      magic: {
         type: Number,
-        default: 100,
+        default: 0,
+      },
+      speed: {
+        type: Number,
+        default: 10,
       },
     },
     achievements: [


### PR DESCRIPTION
- Added a new stat, magic, to the player stats
- Reordered the player stats to show in a consistent order:
  1. Health
  2. Defense
  3. Damage
  4. Magic
  5. Speed
- Updated both the frontend and the backend to maintain consistency